### PR TITLE
解决：在重置列表源时发生错误

### DIFF
--- a/Windows/switch_winget_to_USTCsource.bat
+++ b/Windows/switch_winget_to_USTCsource.bat
@@ -72,7 +72,7 @@ exit /b
 REM 重置执行块
 :Rollback
 echo 重置 Winget 列表源
-winget source reset winget
+winget source reset --force
 taskkill /f /im cmd.exe
 exit /b
 


### PR DESCRIPTION
# 在新机器上运行重置列表源时发生以下错误：

```cmd
REM 重置列表源 为 官方源
winget source reset winget

1. Operation failed: Windows 无法安装程序包 Microsoft.Winget.Source_2024.825.2242.17_neutral__8wekyb3d8bbwe，因为它的版本为 2024.825.2242.17。已安装此程序包的更高版本 2024.826.626.42。 0x80073d06 : �޷���װ�˳��������Ϊ�Ѱ�װ�ó�����ĸ��߰汾��

2. 不到具有以下名称的源：Winget
```

## 解决方案：

使用`winget source reset --force`命令将 winget 和 msstore 重置回初始配置。

```diff
- REM 重置列表源 为 官方源
+ REM 重置列表源
- winget source reset winget
+ winget source reset --force
```

https://github.com/NEANC/Software_Install_Script/issues/19