### PR TITLE
Improve terminal detection and non-interactive CLI output; expose Linux package manager

### DIFF
--- a/internal/installer/linux.go
+++ b/internal/installer/linux.go
@@ -31,6 +31,13 @@ func detectLinuxPackageManager() (string, bool) {
 	return "", false
 }
 
+func (l *LinuxInstaller) PackageManager() string {
+	if l == nil || l.manager == "" {
+		return "unknown"
+	}
+	return l.manager
+}
+
 func (l *LinuxInstaller) Install(packageID string) (*InstallResult, error) {
 	if packageID == "" {
 		return &InstallResult{Package: PackageInfo{ID: packageID}, Status: StatusFailed, Error: fmt.Errorf("empty package ID")}, fmt.Errorf("empty package ID")

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -1,0 +1,11 @@
+package ui
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+func isInteractiveTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}


### PR DESCRIPTION
### Motivation
- Ensure CLI behaves consistently in scripted/non-TTY environments (including PowerShell-like piping) by checking both stdin and stdout TTY state before launching TUIs.
- Make non-interactive `search` produce stable, readable plain-text output and avoid deep `os.Exit` calls inside helpers to allow centralized error handling.
- Surface the detected Linux package manager via an accessor so the status view reflects the real platform package manager instead of always showing `winget`.

### Description
- Added `internal/ui/terminal.go` with `isInteractiveTerminal()` that checks both `stdin` and `stdout` using `golang.org/x/term` and replaced ad-hoc checks with it in `RunStatus()` and `RunSearch()`.
- Refactored `RunSearch()` to call `runSearchPlainText(query) error` in non-interactive sessions and propagate errors to the caller for consistent error rendering, and updated formatting to aligned columns for plain-text search output (`internal/ui/search.go`).
- Switched `RunStatus()` to build the `StatusModel` first, use `isInteractiveTerminal()` to choose TUI vs plain-text, and added `detectPackageManagerName()` plus `renderPlainText()` to report the actual package manager and render status output (`internal/ui/config.go`).
- Added `PackageManager()` on `LinuxInstaller` to expose the detected Linux manager (`internal/installer/linux.go`).

### Testing
- Ran `go test ./...` and all tests passed successfully.
- Built the binary with `go build -o /tmp/sis main.go` and executed a non-interactive command sweep via a script that ran `--help`, `version`, `list`, `status`, `search`, `db status`, `setup --dry-run`, `export`, `install --help`, `uninstall --help`, and `uninstall-all --help`, all returning exit `0`.
- Verified `status` and `search` plain-text outputs via `/tmp/sis status` and `/tmp/sis search curl`, and performed a Windows cross-build with `GOOS=windows GOARCH=amd64 go build -o /tmp/sis.exe main.go` which succeeded.
- PowerShell runtime was not available in the test container (`pwsh`/`powershell` not found), so direct PowerShell-specific interactive tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975f1e55108322bf6a830159dc087d)