### PR TITLE
fix: include release version in artifact filenames and align ldflags to `cmd.version`

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -134,10 +134,10 @@ jobs:
           
           for PLATFORM in "${PLATFORMS[@]}"; do
             IFS='/' read -r GOOS GOARCH SUFFIX <<< "$PLATFORM"
-            OUTPUT="sis-${GOOS}-${GOARCH}${SUFFIX}"
+            OUTPUT="sis-${VERSION}-${GOOS}-${GOARCH}${SUFFIX}"
             
             GOOS=$GOOS GOARCH=$GOARCH go build \
-              -ldflags "-s -w -X main.version=${VERSION}" \
+              -ldflags "-s -w -X cmd.version=${VERSION}" \
               -o "release/${OUTPUT}" \
               main.go
             

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,15 +56,16 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ github.ref_name || github.event.inputs.version }}
         run: |
-          output_name="sis-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}"
-          go build -ldflags "-s -w -X cmd.version=${{ github.ref_name || github.event.inputs.version }}" -o "${output_name}" main.go
+          output_name="sis-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}"
+          go build -ldflags "-s -w -X cmd.version=${VERSION}" -o "${output_name}" main.go
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sis-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: sis-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
+          name: sis-${{ github.ref_name || github.event.inputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: sis-${{ github.ref_name || github.event.inputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
 
   release:
     needs: build

--- a/internal/release/builder.go
+++ b/internal/release/builder.go
@@ -140,7 +140,7 @@ func (bm *BuildManager) buildPlatform(ctx context.Context, platform PlatformConf
 		args = append(args, key, value)
 	}
 
-	args = append(args, "-ldflags", fmt.Sprintf("-s -w -X main.version=%s", version))
+	args = append(args, "-ldflags", fmt.Sprintf("-s -w -X cmd.version=%s", version))
 	args = append(args, ".")
 
 	cmd := exec.CommandContext(ctx, "go", args...)


### PR DESCRIPTION
### Motivation
- The release page showed asset filenames without the release tag which caused confusion where asset names (e.g. on `v0.2.1`) did not reflect the released version. 
- The build invocation previously targeted the wrong variable for ldflags in some places which could cause the embedded binary version to mismatch the CLI expectation. 

### Description
- Updated CI release workflows to include the release version in artifact filenames by setting a `VERSION` env and changing outputs to `sis-${VERSION}-${GOOS}-${GOARCH}${SUFFIX}` in `/.github/workflows/auto-release.yml` and `/.github/workflows/release.yml` so uploaded artifacts carry the tag. 
- Synchronized `upload-artifact` `name`/`path` in `/.github/workflows/release.yml` to include the version so the release page shows assets with the version prefix. 
- Aligned the in-code builder to inject the correct ldflag target by switching to `-X cmd.version=%s` in `internal/release/builder.go` so binaries embed the expected `cmd.version`. 
- Kept artifact naming consistent with the `release-config.json` `artifactNaming` template (which includes `{{.Version}}`). 

### Testing
- Ran `go test ./...` and all tests completed successfully. 
- Verified local edits to `/.github/workflows/auto-release.yml`, `/.github/workflows/release.yml`, and `internal/release/builder.go` and validated that the CI build commands now include `VERSION` and `-X cmd.version` where applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975f667968832285405c33963bdd42)